### PR TITLE
#56308 Anpassungen fuer Kundenreklamation auf AdminLTE

### DIFF
--- a/Template/Elements/lteContainer.php
+++ b/Template/Elements/lteContainer.php
@@ -5,22 +5,22 @@ use exface\AbstractAjaxTemplate\Template\Elements\JqueryContainerTrait;
 class lteContainer extends lteAbstractElement {
 	use JqueryContainerTrait;
 	
-	function generate_html(){
+	/*function generate_html(){
 		return '
 				<div id="' . $this->get_id() . '" class="' . $this->get_width_classes() . ' exf_grid">
 					' . $this->build_html_for_children() . '
 					<div class="col-xs-1" id="' . $this->get_id() . '_sizer" style=""></div>
 				</div>';
-	}
+	}*/
 	
-	function generate_js(){
+	/*function generate_js(){
 		$output = "
 				$('#" . $this->get_id() . "').masonry({columnWidth: '#" . $this->get_id() . "_sizer', itemSelector: '#" . $this->get_id() . " > .exf_grid_item'});
 				$('#" . $this->get_id() . "').children('.exf_grid_item').on('resize', function(event){ $('#" . $this->get_id() . "').masonry('layout'); });
 				";
 		
 		return $output . $this->build_js_for_children();
-	}
+	}*/
 
 }
 ?>

--- a/Template/Elements/lteInputGroup.php
+++ b/Template/Elements/lteInputGroup.php
@@ -1,0 +1,20 @@
+<?php namespace exface\AdminLteTemplate\Template\Elements;
+
+class lteInputGroup extends ltePanel {
+	
+	public function generate_html(){
+		$children_html = $this->build_html_for_children();
+		
+		$output = '
+				<fieldset class="exface_inputgroup">
+					<legend>'.$this->get_widget()->get_caption().'</legend>
+					'.$children_html.'
+				</fieldset>';
+		return $output;
+	}
+	
+	public function generate_js() {
+		
+	}
+}
+?>

--- a/Template/Elements/ltePanel.php
+++ b/Template/Elements/ltePanel.php
@@ -49,5 +49,14 @@ HTML;
 	
 		return $output;
 	}
+	
+	function generate_js(){
+		$output = "
+				$('#" . $this->get_id() . "').masonry({columnWidth: '#" . $this->get_id() . "_sizer', itemSelector: '#" . $this->get_id() . " > .exf_grid_item'});
+				$('#" . $this->get_id() . "').children('.exf_grid_item').on('resize', function(event){ $('#" . $this->get_id() . "').masonry('layout'); });
+				";
+	
+		return $output . $this->build_js_for_children();
+	}
 }
 ?>

--- a/Template/js/template.css
+++ b/Template/js/template.css
@@ -21,6 +21,9 @@ td.nmpd-target{border: 1px solid #d2d6de !important;}
 .datalist-value {margin: 2px 5px;}
 .exf-datalist .placeholder {padding: 8px; line-height: 1.42857143; vertical-align: top; border-top: 1px solid #ddd; background-color: #f9f9f9;}
 
+/* Inputs */
+.exface_inputgroup {border-width: 1px 0 0 0; padding: 10px 0 20px 0;}
+
 /* sortable */
 body.dragging, body.dragging * {
 	cursor: move !important;


### PR DESCRIPTION
Im Gegensatz zum JEasyUi Template wurde hier im Container html und js für ein Masonry_layout erzeugt (bei JEasyUi im Panel). Ich habe hier eine entsprechende Konstellation erzeugt (die generate_js Methode wurde ins Panel verschoben), da sonst der für die Kundenreklamation definierte default-Dialog nicht funktionierte.
Eine lteInputGroup-Klasse wurde geschrieben und die template.css dafür ergänzt.
