### PR TITLE
#56308 Fehleranzeige

### DIFF
--- a/Template/Elements/lteAbstractElement.php
+++ b/Template/Elements/lteAbstractElement.php
@@ -27,7 +27,9 @@ abstract class lteAbstractElement extends AbstractJqueryElement {
 	 * @see \exface\AbstractAjaxTemplate\Template\Elements\AbstractJqueryElement::build_js_show_error_message()
 	 */
 	public function build_js_show_error_message($message_body_js, $title = null){
-		return "swal('" . ($title ? $title : 'Error') . "', " . $message_body_js . ", 'error');";
+		return '
+			swal({html:true, title:' . ($title ? $title : '"Error"') . ', text:' . $message_body_js . '});
+			$(document).trigger("exface.AdminLteTemplate.SweetAlert.Complete");';
 	}
 	
 	/**

--- a/Template/Elements/lteButton.php
+++ b/Template/Elements/lteButton.php
@@ -93,7 +93,7 @@ class lteButton extends lteAbstractElement {
 		return $this->build_js_request_data_collector($action, $input_element) . "
 					$('#" . $this->get_template()->get_element($action->get_dialog_widget())->get_id() . "').find('.modal-body .modal-body-content-wrapper').load(
 							'" . $this->get_ajax_url() . "&resource=".$widget->get_page_id()."&element=".$widget->get_id()."&action=".$widget->get_action_alias()."&data=' + encodeURIComponent(JSON.stringify(requestData)),
-							function() { $(document).trigger('exface.Core.Dialog.complete', ['" . $this->get_template()->get_element($action->get_dialog_widget())->get_id() . "']) });
+							function() { $(document).trigger('exface.AdminLteTemplate.Dialog.Complete', ['" . $this->get_template()->get_element($action->get_dialog_widget())->get_id() . "']) });
 					$('#" . $this->get_template()->get_element($action->get_dialog_widget())->get_id() . "').modal('show');
 					" // Make sure, the input widget of the button is always refreshed, once the dialog is closed again
 		. ($this->build_js_input_refresh($widget, $input_element) ? "$('#" . $this->get_template()->get_element($action->get_dialog_widget())->get_id() . "').one('hide.bs.modal', function(){" . $this->build_js_input_refresh($widget, $input_element) . "});" : "");

--- a/Template/Elements/lteChart.php
+++ b/Template/Elements/lteChart.php
@@ -492,18 +492,20 @@ HTML;
 				<h4 class="modal-title">Table settings</h4>
 			</div>
 			<div class="modal-body">
-				<div role="tabpanel">
-	
-					<!-- Nav tabs -->
-					<ul class="nav nav-tabs" role="tablist">
-						<li role="presentation" class="active"><a href="#{$this->get_id()}_popup_filters" aria-controls="{$this->get_id()}_popup_filters" role="tab" data-toggle="tab">Filters</a></li>
-					</ul>
-					
-					<!-- Tab panes -->
-					<div class="tab-content">
-						<div role="tabpanel" class="tab-pane active" id="{$this->get_id()}_popup_filters">{$filters_html}</div>
+				<div class="modal-body-content-wrapper">
+					<div role="tabpanel">
+		
+						<!-- Nav tabs -->
+						<ul class="nav nav-tabs" role="tablist">
+							<li role="presentation" class="active"><a href="#{$this->get_id()}_popup_filters" aria-controls="{$this->get_id()}_popup_filters" role="tab" data-toggle="tab">Filters</a></li>
+						</ul>
+						
+						<!-- Tab panes -->
+						<div class="tab-content">
+							<div role="tabpanel" class="tab-pane active" id="{$this->get_id()}_popup_filters">{$filters_html}</div>
+						</div>
+				
 					</div>
-			
 				</div>
 			</div>
 			<div class="modal-footer">

--- a/Template/Elements/lteDataTable.php
+++ b/Template/Elements/lteDataTable.php
@@ -706,22 +706,24 @@ JS;
 				<h4 class="modal-title">Table settings</h4>
 			</div>
 			<div class="modal-body">
-				<div role="tabpanel">
-
-					<!-- Nav tabs -->
-					<ul class="nav nav-tabs" role="tablist">
-						<li role="presentation" class="active"><a href="#{$this->get_id()}_popup_filters" aria-controls="{$this->get_id()}_popup_filters" role="tab" data-toggle="tab">Filters</a></li>
-						<li role="presentation"><a href="#{$this->get_id()}_popup_columns" aria-controls="{$this->get_id()}_popup_columns" role="tab" data-toggle="tab">Columns</a></li>
-						<li role="presentation"><a href="#{$this->get_id()}_popup_sorting" aria-controls="{$this->get_id()}_popup_sorting" role="tab" data-toggle="tab">Sorting</a></li>
-					</ul>
-									
-					<!-- Tab panes -->
-					<div class="tab-content">
-						<div role="tabpanel" class="tab-pane active" id="{$this->get_id()}_popup_filters">{$filters_html}</div>
-						<div role="tabpanel" class="tab-pane" id="{$this->get_id()}_popup_columns">{$columns_html}</div>
-						<div role="tabpanel" class="tab-pane" id="{$this->get_id()}_popup_sorting">{$sorting_html}</div>
+				<div class="modal-body-content-wrapper">
+					<div role="tabpanel">
+	
+						<!-- Nav tabs -->
+						<ul class="nav nav-tabs" role="tablist">
+							<li role="presentation" class="active"><a href="#{$this->get_id()}_popup_filters" aria-controls="{$this->get_id()}_popup_filters" role="tab" data-toggle="tab">Filters</a></li>
+							<li role="presentation"><a href="#{$this->get_id()}_popup_columns" aria-controls="{$this->get_id()}_popup_columns" role="tab" data-toggle="tab">Columns</a></li>
+							<li role="presentation"><a href="#{$this->get_id()}_popup_sorting" aria-controls="{$this->get_id()}_popup_sorting" role="tab" data-toggle="tab">Sorting</a></li>
+						</ul>
+										
+						<!-- Tab panes -->
+						<div class="tab-content">
+							<div role="tabpanel" class="tab-pane active" id="{$this->get_id()}_popup_filters">{$filters_html}</div>
+							<div role="tabpanel" class="tab-pane" id="{$this->get_id()}_popup_columns">{$columns_html}</div>
+							<div role="tabpanel" class="tab-pane" id="{$this->get_id()}_popup_sorting">{$sorting_html}</div>
+						</div>
+						
 					</div>
-					
 				</div>
 			</div>
 			<div class="modal-footer">

--- a/Template/Elements/lteDataTable.php
+++ b/Template/Elements/lteDataTable.php
@@ -302,9 +302,6 @@ $(document).ready(function() {
 			"error": function(result){
 				{$this->build_js_busy_icon_hide()}
 				swal('Server error '+result.status, 'Sorry, your request could not be processed correctly. Please contact an administrator!', 'error');
-			},
-			"complete": function() {
-				$(document).trigger("exface.Core.DataTable.Ajax.Complete", ["{$this->get_id()}"]);
 			}
 		},
 		"language": {

--- a/Template/Elements/lteTab.php
+++ b/Template/Elements/lteTab.php
@@ -1,0 +1,41 @@
+<?php namespace exface\AdminLteTemplate\Template\Elements;
+
+class lteTab extends ltePanel {
+
+	function generate_html(){
+		$output = '
+	<div id="' . $this->get_id() . '" class="nav-tabs-custom">
+		<ul class="nav nav-tabs">
+			' . $this->generate_html_header() . '
+		</ul>
+		<div class="tab-content">
+			' . $this->generate_html_content() . '
+		</div>
+	</div>';
+		
+		return $output;
+	}
+	
+	function generate_html_header() {
+		//der erste Tab ist aktiv
+		$active_class = $this->get_widget() === $this->get_widget()->get_parent()->get_children()[0] ? ' active' : '';
+		
+		$output = '
+	<li class="' . $active_class . '"><a href="#' . $this->get_id() . '" data-toggle="tab">' . $this->get_widget()->get_caption() . '</a></li>';
+		return $output;
+	}
+	
+	function generate_html_content() {
+		//der erste Tab ist aktiv
+		$active_class = $this->get_widget() === $this->get_widget()->get_parent()->get_children()[0] ? ' active' : '';
+		
+		$output =
+	'<div class="tab-pane' . $active_class . '" id="' . $this->get_id() . '">
+		<div class="tab-pane-content-wrapper">
+			' . $this->build_html_for_children() . '
+		</div>
+	</div>';
+		return $output;
+	}
+}
+?>

--- a/Template/Elements/lteTabs.php
+++ b/Template/Elements/lteTabs.php
@@ -1,0 +1,26 @@
+<?php namespace exface\AdminLteTemplate\Template\Elements;
+
+class lteTabs extends lteContainer {
+
+	function generate_html(){
+		$header_html = '';
+		$content_html = '';
+		foreach ($this->get_widget()->get_children() as $tab) {
+			$header_html .= $this->get_template()->get_element($tab)->generate_html_header();;
+			$content_html .= $this->get_template()->get_element($tab)->generate_html_content();
+		}
+		
+		$output = '
+	<div id="' . $this->get_id() . '" class="nav-tabs-custom">
+		<ul class="nav nav-tabs">
+			' . $header_html . '
+		</ul>
+		<div class="tab-content">
+			' . $content_html . '
+		</div>
+	</div>';
+	
+		return $output;
+	}
+}
+?>

--- a/Template/js/template.css
+++ b/Template/js/template.css
@@ -162,3 +162,20 @@ ol li.highlight i.icon-move {}
 .navbar-nav > .favorites-menu > .dropdown-menu > li .menu > li > a > .ion {
   width: 20px;
 }
+
+/* SweetAlert */
+.sweet-alert {
+	width: 50vw !important;
+	left: 25vw !important;
+	top: 10px !important;
+	margin: 0 !important;
+}
+.sweet-alert .tab-pane {
+	height: 315px;
+	height: -webkit-calc(100vh - 260px);
+	height: -moz-calc(100vh - 260px);
+	height: -ms-calc(100vh - 260px);
+	height: -o-calc(100vh - 260px);
+	height: calc(100vh - 260px);
+	overflow: auto;
+}

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
 		"bower-asset/masonry" : ">=4",
 		"bower-asset/jquery-sortable" : ">=0.9",
 		"bower-asset/jquery-numpad" : "~1.4",
-		"npm-asset/flot-charts" : ">0.8"
+		"npm-asset/flot-charts" : ">0.8",
+		"cubiq/iscroll" : ">=5.2",
+		"vitch/jScrollPane" : ">=2.0.23",
+		"uxsolutions/bootstrap-datepicker" : ">=1.6"
 	}
 }


### PR DESCRIPTION
Ordentliche Anzeige von Fehlermeldungen im AdminLteTemplate.

lteAbstractElement:
- Der Html-Code wurde bisher von SweetAlert als Text angezeigt. Jetzt wird es als Html interpretiert. Da SweetAlert keine passenden Events zur Verfügung stellt wurde ein selbst definiertes Event implementiert, um die Scroller extern aktivieren zu können.

lteButton:
- Das selbst definierte Event wurde umbenannt (konnte nicht sinnvoll ersetzt werden: resize wird nicht getriggert, DOMNodeInserted wird dagegen extrem häufig getriggert).

lteDataTable:
- Das selbst definierte Event wurde entfernt (konnte durch draw.dt ersetzt werden).

lteTab, lteTabs:
- neu implementiert

template.css:
- Anpassung der Anzeige der SweetAlert-Nachrichten
