### PR TITLE
#57324 composer.json korrigiert und neuen Datepicker verwendet

### DIFF
--- a/Template/Elements/lteInputDate.php
+++ b/Template/Elements/lteInputDate.php
@@ -59,8 +59,8 @@ class lteInputDate extends lteInput {
 	
 	public function generate_headers(){
 		$headers = parent::generate_headers();
-		$headers[] = '<script type="text/javascript" src="exface/vendor/almasaeed2010/adminlte/plugins/datepicker/bootstrap-datepicker.js"></script>';
-		$headers[] = '<link rel="stylesheet" href="exface/vendor/almasaeed2010/adminlte/plugins/datepicker/datepicker3.css">';
+		$headers[] = '<script type="text/javascript" src="exface/vendor/bower-asset/bootstrap-datepicker/dist/js/bootstrap-datepicker.js"></script>';
+		$headers[] = '<link rel="stylesheet" href="exface/vendor/bower-asset/bootstrap-datepicker/dist/css/bootstrap-datepicker3.css">';
 		return $headers;
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
 		"bower-asset/masonry" : ">=4",
 		"bower-asset/jquery-sortable" : ">=0.9",
 		"bower-asset/jquery-numpad" : "~1.4",
-		"npm-asset/flot-charts" : ">0.8",
-		"cubiq/iscroll" : ">=5.2",
-		"vitch/jScrollPane" : ">=2.0.23",
-		"uxsolutions/bootstrap-datepicker" : ">=1.6"
+		"bower-asset/iscroll" : ">=5.2",
+		"bower-asset/jScrollPane" : ">=2.0.23",
+		"bower-asset/bootstrap-datepicker" : ">=1.6",
+		"npm-asset/flot-charts" : ">0.8"
 	}
 }


### PR DESCRIPTION
AdminLte verwendet eine aeltere Version des Datepickers, in welcher
die Formatoption nicht funktioniert. Deshalb wird die aktuelle Version
manuell eingebunden.