### PR TITLE
#FIX DataTable-Header streckt sich wenn SideBar geschlossen wird

### DIFF
--- a/Template/js/template.css
+++ b/Template/js/template.css
@@ -25,7 +25,11 @@ table.dataTable tfoot th.dt-body-right {padding-right: 10px;}
 table.dataTable td.ok{background-color: green;}
 table.dataTable td.warning{background-color: yellow;}
 table.dataTable td.error{background-color: red; color: white;}
-
+/* So wird der DataTable-Header entsprechend dem DataTable-Body gestaucht
+   wenn die SideBar geoeffnet wird. */
+.dataTables_scrollHeadInner, .dataTables_scrollHeadInner .table {
+	width: 100% !important;
+}
 
 /* jQuery NumPad */
 td.nmpd-target{border: 1px solid #d2d6de !important;}


### PR DESCRIPTION
Vorher hat sich die Breite des DataTable-Headers nicht geaendert wenn die Sidebar geöffnet oder geschlossen wurde. Dadurch waren die Spaltenüberschriften nicht mehr über den Spalten angeordnet.
