### PR TITLE
#FIX Spaltenbreiten in DataTable Header, Body stimmen nicht ueberein

### DIFF
--- a/Template/Elements/lteDataTable.php
+++ b/Template/Elements/lteDataTable.php
@@ -361,6 +361,14 @@ function {$this->buildJsFunctionPrefix()}Init(){
 	$('#{$this->getId()}_popup_columnList').sortable();
 	
 	context.init({preventDoubleContext: false});
+    
+    // Code der bei DataTable onResize ausgefuehrt wird
+    new ResizeSensor(document.getElementById("{$this->getId()}"), function() {
+        // Die Spaltenbreiten in Header und Body werden synchronisiert. Die Ursache ist folg-
+        // endes aelteres Problem: https://datatables.net/forums/discussion/5771/row-headers-resize,
+        // und besteht scheinbar noch immer.
+        {$this->getId()}_table.columns.adjust();
+    });
 }
 	
 function setColumnVisibility(name, visible){
@@ -579,6 +587,9 @@ JS;
         $includes[] = '<link rel="stylesheet" type="text/css" href="exface/vendor/exface/AdminLteTemplate/Template/js/context.js/context.bootstrap.css">';
         $includes[] = '<script type="text/javascript" src="exface/vendor/exface/AdminLteTemplate/Template/js/context.js/context.js"></script>';
         // $includes[] = '<script type="text/javascript" src="exface/vendor/exface/AdminLteTemplate/Template/js/jquery.contextmenu.js"></script>';
+        
+        // Resize-Sensor
+        $includes[] = '<script src="exface/vendor/npm-asset/css-element-queries/src/ResizeSensor.js"></script>';
         
         return $includes;
     }

--- a/Template/js/template.css
+++ b/Template/js/template.css
@@ -29,11 +29,6 @@ table.dataTable tfoot th.dt-body-right {padding-right: 10px;}
 table.dataTable td.ok{background-color: green;}
 table.dataTable td.warning{background-color: yellow;}
 table.dataTable td.error{background-color: red; color: white;}
-/* So wird der DataTable-Header entsprechend dem DataTable-Body gestaucht
-   wenn die SideBar geoeffnet wird. */
-.dataTables_scrollHeadInner, .dataTables_scrollHeadInner .table {
-	width: 100% !important;
-}
 
 /* jQuery NumPad */
 td.nmpd-target{border: 1px solid #d2d6de !important;}

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
 		"bower-asset/jScrollPane" : "^2.0.23",
 		"bower-asset/font-awesome" : "^4.7",
 		"bower-asset/ionicons" : "^2.0.1",
-		"npm-asset/flot-charts" : "~0.8"
+		"npm-asset/flot-charts" : "~0.8",
+		"npm-asset/css-element-queries" : "^0.4"
 	},
     "autoload": {
         "psr-4": { "exface\\AdminLteTemplate\\": "" },


### PR DESCRIPTION
Ein aelterer FIX per css wurde entfernt, er funktionierte nicht wenn
die Spalten insgesamt breiter waren als die Breite des Fensters
(horizontales Scrollen notwendig). Die jetzige Loesung funktioniert
auch dann.