### PR TITLE
#FIX Fehler in Uebersetzungsdateien behoben

### DIFF
--- a/Translations/exface.AdminLteTemplate.de.json
+++ b/Translations/exface.AdminLteTemplate.de.json
@@ -1,27 +1,27 @@
 {
-	"REFRESH": "Aktualisieren",
+	"DATE.FORMAT.INTERNAL": "yyyy-MM-dd",
+	"DATE.FORMAT.SCREEN": "dd.MM.yyyy",
+	"DATETIME.FORMAT.INTERNAL": "yyyy-MM-dd HH:mm:ss",
+	"DATETIME.FORMAT.SCREEN": "dd.MM.yyyy HH:mm:ss",
 	
-	"MESSAGE.SELECT_EXACTLY_X_ROWS": "Bitte genau %number% Zeile auswählen!|Bitte genau %number% Zeilen auswählen!",
-	"MESSAGE.SELECT_AT_MOST_X_ROWS": "Bitte maximal %number% Zeile auswählen!|Bitte maximal %number% Zeilen auswählen!",
-	"MESSAGE.SELECT_AT_LEAST_X_ROWS": "Bitte mindestens %number% Zeile auswählen!|Bitte mindestens %number% Zeilen auswählen!",
-	"MESSAGE.SELECT_X_TO_Y_ROWS": "Bitte %min% bis %max% Zeilen auswählen!",
 	"MESSAGE.ERROR_TITLE": "Fehler",
-	"MESSAGE.SUCCESS_TITLE": "",
 	"MESSAGE.FILL_REQUIRED_ATTRIBUTES": "Bitte füllen Sie die benötigten Felder aus: ",
+	"MESSAGE.SELECT_AT_LEAST_X_ROWS": "Bitte mindestens %number% Zeile auswählen!|Bitte mindestens %number% Zeilen auswählen!",
+	"MESSAGE.SELECT_AT_MOST_X_ROWS": "Bitte maximal %number% Zeile auswählen!|Bitte maximal %number% Zeilen auswählen!",
+	"MESSAGE.SELECT_EXACTLY_X_ROWS": "Bitte genau %number% Zeile auswählen!|Bitte genau %number% Zeilen auswählen!",
+	"MESSAGE.SELECT_X_TO_Y_ROWS": "Bitte %min% bis %max% Zeilen auswählen!",
+	"MESSAGE.SUCCESS_TITLE": "",
+	
+	"REFRESH": "Aktualisieren",
 	
     "WIDGET.CHART.SETTINGS_DIALOG_TITLE": "Grafik-Einstellungen",
     
+    "WIDGET.COMBOTABLE.MAX_SELECTION": "Sie können nicht mehr als %number% Eintrag auswählen|Sie können nicht mehr als %number% Einträge auswählen",
     "WIDGET.COMBOTABLE.NO_SUGGESTION": "Keine Resultate",
     "WIDGET.COMBOTABLE.PLACEHOLDER": "",
-    "WIDGET.COMBOTABLE.MAX_SELECTION": "Sie können nicht mehr als %number% Eintrag auswählen|Sie können nicht mehr als %number% Einträge auswählen",
-
-	"WIDGET.DATATABLE.SETTINGS_DIALOG.TITLE": "Tabelleneinstellungen",
+    
 	"WIDGET.DATATABLE.SETTINGS_DIALOG.COLUMNS": "Spalten",
+	"WIDGET.DATATABLE.SETTINGS_DIALOG.TITLE": "Tabelleneinstellungen",
 	
-	"DATE.FORMAT.SCREEN": "dd.MM.yyyy",
-	"DATE.FORMAT.INTERNAL": "yyyy-MM-dd",
-	"DATETIME.FORMAT.SCREEN": "dd.MM.yyyy HH:mm:ss",
-	"DATETIME.FORMAT.INTERNAL": "yyyy-MM-dd HH:mm:ss",
-
 	"WIDGET.REFRESH": "Aktualisieren"
 }

--- a/Translations/exface.AdminLteTemplate.de.json
+++ b/Translations/exface.AdminLteTemplate.de.json
@@ -1,4 +1,6 @@
 {
+	"REFRESH": "Aktualisieren",
+	
 	"MESSAGE.SELECT_EXACTLY_X_ROWS": "Bitte genau %number% Zeile auswählen!|Bitte genau %number% Zeilen auswählen!",
 	"MESSAGE.SELECT_AT_MOST_X_ROWS": "Bitte maximal %number% Zeile auswählen!|Bitte maximal %number% Zeilen auswählen!",
 	"MESSAGE.SELECT_AT_LEAST_X_ROWS": "Bitte mindestens %number% Zeile auswählen!|Bitte mindestens %number% Zeilen auswählen!",
@@ -16,14 +18,10 @@
 	"WIDGET.DATATABLE.SETTINGS_DIALOG.TITLE": "Tabelleneinstellungen",
 	"WIDGET.DATATABLE.SETTINGS_DIALOG.COLUMNS": "Spalten",
 	
-	"WIDGET.COMBOTABLE.NO_SUGGESTION": "Keine Resultate",
-	"WIDGET.COMBOTABLE.PLACEHOLDER": "",
-	"WIDGET.COMBOTABLE.MAX_SELECTION": "Sie können nicht mehr als %number% Eintrag auswählen|Sie können nicht mehr als %number% Einträge auswählen",
-	
 	"DATE.FORMAT.SCREEN": "dd.MM.yyyy",
 	"DATE.FORMAT.INTERNAL": "yyyy-MM-dd",
 	"DATETIME.FORMAT.SCREEN": "dd.MM.yyyy HH:mm:ss",
-	"DATETIME.FORMAT.INTERNAL": "yyyy-MM-dd HH:mm:ss"
+	"DATETIME.FORMAT.INTERNAL": "yyyy-MM-dd HH:mm:ss",
 
 	"WIDGET.REFRESH": "Aktualisieren"
 }

--- a/Translations/exface.AdminLteTemplate.en.json
+++ b/Translations/exface.AdminLteTemplate.en.json
@@ -9,17 +9,19 @@
 	"MESSAGE.SUCCESS_TITLE": "",
 	"MESSAGE.FILL_REQUIRED_ATTRIBUTES": "Please fill in the required fields: ",
 	
-	"WIDGET.DATATABLE.SETTINGS_DIALOG.TITLE": "Table Settings",
-    
-	"WIDGET.DATATABLE.SETTINGS_DIALOG.COLUMNS": "Columns",
-	"WIDGET.REFRESH": "Refresh",
+	"WIDGET.CHART.SETTINGS_DIALOG_TITLE": "Chart Settings",
 	
 	"WIDGET.COMBOTABLE.NO_SUGGESTION": "No suggestions",
 	"WIDGET.COMBOTABLE.PLACEHOLDER": "",
 	"WIDGET.COMBOTABLE.MAX_SELECTION": "You cannot choose more than %number% item|You cannot choose more than %number% items",
 	
+	"WIDGET.DATATABLE.SETTINGS_DIALOG.TITLE": "Table Settings",
+	"WIDGET.DATATABLE.SETTINGS_DIALOG.COLUMNS": "Columns",
+	
 	"DATE.FORMAT.SCREEN": "yyyy-MM-dd",
 	"DATE.FORMAT.INTERNAL": "yyyy-MM-dd",
 	"DATETIME.FORMAT.SCREEN": "yyyy-MM-dd HH:mm:ss",
-	"DATETIME.FORMAT.INTERNAL": "yyyy-MM-dd HH:mm:ss"
+	"DATETIME.FORMAT.INTERNAL": "yyyy-MM-dd HH:mm:ss",
+	
+	"WIDGET.REFRESH": "Refresh"
 }

--- a/Translations/exface.AdminLteTemplate.en.json
+++ b/Translations/exface.AdminLteTemplate.en.json
@@ -1,27 +1,27 @@
 {
-	"REFRESH": "Refresh",
+	"DATE.FORMAT.INTERNAL": "yyyy-MM-dd",
+	"DATE.FORMAT.SCREEN": "yyyy-MM-dd",
+	"DATETIME.FORMAT.INTERNAL": "yyyy-MM-dd HH:mm:ss",
+	"DATETIME.FORMAT.SCREEN": "yyyy-MM-dd HH:mm:ss",
 	
-	"MESSAGE.SELECT_EXACTLY_X_ROWS": "Please select exactly %number% row!|Please select exactly %number% rows!",
-	"MESSAGE.SELECT_AT_MOST_X_ROWS": "Please select at most %number% row!|Please select at most %number% rows!",
-	"MESSAGE.SELECT_AT_LEAST_X_ROWS": "Please select at least %number% row!|Please select at least %number% rows!",
-	"MESSAGE.SELECT_X_TO_Y_ROWS": "Please select %min% to %max% rows first!",
 	"MESSAGE.ERROR_TITLE": "Error",
-	"MESSAGE.SUCCESS_TITLE": "",
 	"MESSAGE.FILL_REQUIRED_ATTRIBUTES": "Please fill in the required fields: ",
+	"MESSAGE.SELECT_AT_LEAST_X_ROWS": "Please select at least %number% row!|Please select at least %number% rows!",
+	"MESSAGE.SELECT_AT_MOST_X_ROWS": "Please select at most %number% row!|Please select at most %number% rows!",
+	"MESSAGE.SELECT_EXACTLY_X_ROWS": "Please select exactly %number% row!|Please select exactly %number% rows!",
+	"MESSAGE.SELECT_X_TO_Y_ROWS": "Please select %min% to %max% rows first!",
+	"MESSAGE.SUCCESS_TITLE": "",
+	
+	"REFRESH": "Refresh",
 	
 	"WIDGET.CHART.SETTINGS_DIALOG_TITLE": "Chart Settings",
 	
+	"WIDGET.COMBOTABLE.MAX_SELECTION": "You cannot choose more than %number% item|You cannot choose more than %number% items",
 	"WIDGET.COMBOTABLE.NO_SUGGESTION": "No suggestions",
 	"WIDGET.COMBOTABLE.PLACEHOLDER": "",
-	"WIDGET.COMBOTABLE.MAX_SELECTION": "You cannot choose more than %number% item|You cannot choose more than %number% items",
 	
-	"WIDGET.DATATABLE.SETTINGS_DIALOG.TITLE": "Table Settings",
 	"WIDGET.DATATABLE.SETTINGS_DIALOG.COLUMNS": "Columns",
-	
-	"DATE.FORMAT.SCREEN": "yyyy-MM-dd",
-	"DATE.FORMAT.INTERNAL": "yyyy-MM-dd",
-	"DATETIME.FORMAT.SCREEN": "yyyy-MM-dd HH:mm:ss",
-	"DATETIME.FORMAT.INTERNAL": "yyyy-MM-dd HH:mm:ss",
+	"WIDGET.DATATABLE.SETTINGS_DIALOG.TITLE": "Table Settings",
 	
 	"WIDGET.REFRESH": "Refresh"
 }


### PR DESCRIPTION
Fehlendes Komma, doppelte Eintraege. Die Dateien wurden ausserdem aneinander angepasst und ein fehlender Eintrag ergaenzt.