### PR TITLE
#FIX Fehler im Masonry-Layout

### DIFF
--- a/Template/Elements/lteAbstractElement.php
+++ b/Template/Elements/lteAbstractElement.php
@@ -56,9 +56,12 @@ abstract class lteAbstractElement extends AbstractJqueryElement
      */
     public function buildJsShowError($message_body_js, $title = null)
     {
-        return '
-			adminLteCreateDialog($("#ajax-dialogs").append(\'<div class="ajax-wrapper"></div>\').children(".ajax-wrapper").last(), "error", ' . ($title ? $title : '"' . $this->translate('MESSAGE.ERROR_TITLE') . '"') . ', ' . $message_body_js . ');
-			';
+        $titleScript = $title ? $title : '"' . $this->translate('MESSAGE.ERROR_TITLE') . '"';
+        
+        return <<<JS
+
+            adminLteCreateDialog($("#ajax-dialogs").append("<div class='ajax-wrapper'></div>").children(".ajax-wrapper").last(), "error", {$titleScript}, {$message_body_js}, "error_tab_layouter()");
+JS;
     }
 
     /**

--- a/Template/Elements/lteInputText.php
+++ b/Template/Elements/lteInputText.php
@@ -17,9 +17,7 @@ class lteInputText extends lteInput
                                 id="{$this->getId()}"
                                 style="height: {$this->getHeight()}; width: 100%;" 
                                 {$requiredScript}
-                                {$disabledScript}>
-                            {$this->getValueWithDefaults()}
-                        </textarea>
+                                {$disabledScript}>{$this->getValueWithDefaults()}</textarea>
 HTML;
         
         return $this->buildHtmlWrapper($output);

--- a/Template/js/template.js
+++ b/Template/js/template.js
@@ -164,7 +164,7 @@ function contextShowMenu(containerSelector){
 			$(containerSelector).find('.dropdown-menu').empty().append('<li></li>').children('li:first-of-type').append($data);
 		},
 		error: function(jqXHR, textStatus, errorThrown){
-			adminLteCreateDialog($("body"), "error", jqXHR.responseText, jqXHR.status + " " + jqXHR.statusText);
+			adminLteCreateDialog($("body"), "error", jqXHR.responseText, jqXHR.status + " " + jqXHR.statusText, "error_tab_layouter()");
 		}
 	});
 }
@@ -173,7 +173,7 @@ function getPageId(){
 	return $("meta[name='page_id']").attr("content");
 }
 
-function adminLteCreateDialog(parentElement, id, title, content){
+function adminLteCreateDialog(parentElement, id, title, content, onShownFunction){
 	var dialog = $(' \
 		<div class="modal" id="'+id+'"> \
 			<div class="modal-dialog modal-lg"> \
@@ -187,7 +187,12 @@ function adminLteCreateDialog(parentElement, id, title, content){
 					</div> \
 				</div><!-- /.modal-content --> \
 			</div><!-- /.modal-dialog --> \
-		</div><!-- /.modal -->').resize();
+		</div><!-- /.modal --> \
+		<script type="text/javascript"> \
+			$("#'+id+'").on("shown.bs.modal", function() { \
+				' + onShownFunction + '; \
+			}); \
+		</script>').resize();
 	parentElement.append(dialog);
 	$('#'+id).modal('show');
 }


### PR DESCRIPTION
Beim Oeffnen einer Fehlermeldung muss der Masonry-Layouter fuerden ersten Tab (error_tab) gestartet werden.
Es wurde versehentlich ein Wert (mehrere Leerzeichen) fuer das InputText-Widget gesetzt.